### PR TITLE
test with nightlies

### DIFF
--- a/external_tests/test_emcee.py
+++ b/external_tests/test_emcee.py
@@ -120,11 +120,8 @@ class TestDataEmcee:
         with pytest.raises(ValueError):
             from_emcee(sampler, blob_names=["inexistent"])
 
-    @pytest.mark.filterwarnings(
-        "ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning"
-    )
     def test_peculiar_blobs(self, data):
-        sampler = emcee.EnsembleSampler(6, 1, lambda x: (-(x**2), (np.random.normal(x), 3)))
+        sampler = emcee.EnsembleSampler(6, 1, lambda x: (-np.sum(x**2), (np.random.normal(x), 3)))
         sampler.run_mcmc(np.random.normal(size=(6, 1)), 20)
         inference_data = from_emcee(sampler, blob_names=["normal", "threes"])
         fails = check_multiple_attrs({"log_likelihood": ["normal", "threes"]}, inference_data)
@@ -133,11 +130,8 @@ class TestDataEmcee:
         fails = check_multiple_attrs({"log_likelihood": ["mix"]}, inference_data)
         assert not fails
 
-    @pytest.mark.filterwarnings(
-        "ignore:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning"
-    )
     def test_single_blob(self):
-        sampler = emcee.EnsembleSampler(6, 1, lambda x: (-(x**2), 3))
+        sampler = emcee.EnsembleSampler(6, 1, lambda x: (-np.sum(x**2), 3))
         sampler.run_mcmc(np.random.normal(size=(6, 1)), 20)
         inference_data = from_emcee(sampler, blob_names=["blob"], blob_groups=["blob_group"])
         fails = check_multiple_attrs({"blob_group": ["blob"]}, inference_data)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,24 +1,55 @@
+# pylint: disable=redefined-outer-name
+"""Test configuration and global fixtures."""
 import numpy as np
 import pytest
-from arviz_base import load_arviz_data
+from arviz_base import from_dict
 
 
 @pytest.fixture(scope="module")
 def draws():
     """Share default draw count."""
-    return 500
+    return 10
 
 
 @pytest.fixture(scope="module")
 def chains():
     """Share default chain count."""
-    return 2
+    return 3
 
 
 @pytest.fixture(scope="module")
-def centered_eight():
+def centered_eight(draws, chains):
     """Share default chain count."""
-    return load_arviz_data("centered_eight").load()
+    rng = np.random.default_rng(31)
+    mu = rng.normal(size=(chains, draws))
+    theta = rng.normal(size=(chains, draws, 8))
+    tau = rng.normal(size=(chains, draws))
+    diverging = rng.choice([True, False], size=(chains, draws), p=[0.1, 0.9])
+    mu_prior = rng.normal(size=(chains, draws))
+    theta_prior = rng.normal(size=(chains, draws, 8))
+    tau_prior = rng.normal(size=(chains, draws))
+    y = rng.normal(size=(chains, draws, 8))
+    school = [
+        "Choate",
+        "Deerfield",
+        "Phillips Andover",
+        "Phillips Exeter",
+        "Hotchkiss",
+        "Lawrenceville",
+        "St. Paul's",
+        "Mt. Hermon",
+    ]
+
+    return from_dict(
+        {
+            "posterior": {"mu": mu, "theta": theta, "tau": tau},
+            "sample_stats": {"diverging": diverging},
+            "prior": {"mu": mu_prior, "theta": theta_prior, "tau": tau_prior},
+            "posterior_predictive": {"y": y},
+        },
+        dims={"theta": ["school"], "y": ["school"]},
+        coords={"school": school},
+    )
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -18,6 +18,11 @@ from arviz_base.datasets import LOCAL_DATASETS, REMOTE_DATASETS, RemoteFileMetad
 from datatree import DataTree
 from xarray.testing import assert_allclose
 
+netcdf_nightlies_skip = pytest.mark.skipif(
+    os.environ.get("NIGHTLIES", False) == "TRUE",
+    reason="Skip netcdf4 dependent tests from nightlies as it generally takes longer to update.",
+)
+
 
 @pytest.fixture(autouse=True)
 def no_remote_data(monkeypatch, tmpdir):
@@ -68,6 +73,7 @@ def no_remote_data(monkeypatch, tmpdir):
     )
 
 
+@netcdf_nightlies_skip
 @pytest.mark.filterwarnings("ignore:numpy.ndarray size changed")
 def test_load_local_arviz_data():
     idata = load_arviz_data("centered_eight")
@@ -85,6 +91,7 @@ def test_load_local_arviz_data():
     assert idata.posterior["theta"].dims == ("chain", "draw", "school")
 
 
+@netcdf_nightlies_skip
 def test_clear_data_home():
     resource = REMOTE_DATASETS["test_remote"]
     assert not os.path.exists(resource.filename)
@@ -94,6 +101,7 @@ def test_clear_data_home():
     assert not os.path.exists(resource.filename)
 
 
+@netcdf_nightlies_skip
 def test_load_remote_arviz_data():
     assert load_arviz_data("test_remote")
 

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -1,9 +1,15 @@
 # pylint: disable=no-member, no-self-use, invalid-name, redefined-outer-name
+import os
 
 import numpy as np
 import pytest
 import xarray as xr
 from arviz_base import convert_to_dataset, convert_to_datatree, extract
+
+netcdf_nightlies_skip = pytest.mark.skipif(
+    os.environ.get("NIGHTLIES", False) == "TRUE",
+    reason="Skip netcdf4 dependent tests from nightlies as it generally takes longer to update.",
+)
 
 
 def test_1d_dataset():
@@ -136,6 +142,7 @@ def test_convert_to_datatree_idempotent():
     assert first.prior is second.prior
 
 
+@netcdf_nightlies_skip
 def test_convert_to_datatree_from_file(tmpdir):
     first = convert_to_datatree(np.random.randn(1, 100), group="prior")
     filename = str(tmpdir.join("test_file.nc"))
@@ -149,6 +156,7 @@ def test_convert_to_datatree_bad():
         convert_to_datatree(1)
 
 
+@netcdf_nightlies_skip
 def test_convert_to_dataset_bad(tmpdir):
     first = convert_to_datatree(np.random.randn(1, 100), group="prior")
     filename = str(tmpdir.join("test_file.nc"))

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -198,22 +198,22 @@ class TestDataConvert:
 
 
 class TestExtract:
-    def test_default(self, centered_eight):
+    def test_default(self, centered_eight, chains, draws):
         post = extract(centered_eight)
         assert isinstance(post, xr.Dataset)
         assert "sample" in post.sizes
-        assert post.theta.size == (4 * 500 * 8)
+        assert post.theta.size == (chains * draws * 8)
 
     def test_seed(self, centered_eight):
         post = extract(centered_eight, rng=7)
         post_pred = extract(centered_eight, group="posterior_predictive", rng=7)
         assert all(post.sample == post_pred.sample)
 
-    def test_no_combine(self, centered_eight):
+    def test_no_combine(self, centered_eight, chains, draws):
         post = extract(centered_eight, combined=False)
         assert "sample" not in post.sizes
-        assert post.sizes["chain"] == 4
-        assert post.sizes["draw"] == 500
+        assert post.sizes["chain"] == chains
+        assert post.sizes["draw"] == draws
 
     def test_var_name_group(self, centered_eight):
         prior = extract(centered_eight, group="prior", var_names="the", filter_vars="like")

--- a/tox.ini
+++ b/tox.ini
@@ -2,16 +2,17 @@
 envlist =
     check
     docs
-    {py310,py311,py312,nightlies}{,-coverage}
+    nightlies
+    {py310,py311,py312}{,-coverage}
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
 isolated_build_env = build
 
 [gh-actions]
 python =
-    3.10: py310
-    3.11: py311, check, nightlies
-    3.12: py312
+    3.10: py310-coverage
+    3.11: py311-coverage, check, nightlies
+    3.12: py312-coverage
 
 [testenv]
 basepython =
@@ -21,12 +22,6 @@ basepython =
     py312: python3.12
     # See https://github.com/tox-dev/tox/issues/1548
     {check,docs,cleandocs,viewdocs,build}: python3
-install_command = 
-    {py310,py311,py312,check,docs,cleandocs,viewdocs,build}: python -I -m pip install {opts} {packages}
-    nightlies: python -I -m pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple {opts} {packages}
-pip_pre =
-    {py310,py311,py312,check,docs,cleandocs,viewdocs,build}: false
-    nightlies: true
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = -s
@@ -38,6 +33,10 @@ extras =
     netcdf4
 commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:-vv}
+
+[testenv:nightlies]
+install_command = python -I -m pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple {opts} {packages}
+pip_pre = true
 
 [testenv:check]
 description = perform style checks

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,8 @@ commands =
 [testenv:nightlies]
 install_command = python -I -m pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple {opts} {packages}
 pip_pre = true
+setenv =
+  NIGHTLIES=TRUE
 
 [testenv:check]
 description = perform style checks

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist =
     check
     docs
-    {py310,py311,py312}{,-coverage}
+    {py310,py311,py312,nightlies}{,-coverage}
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
 isolated_build_env = build
@@ -10,16 +10,23 @@ isolated_build_env = build
 [gh-actions]
 python =
     3.10: py310
-    3.11: py311
+    3.11: py311, check, nightlies
     3.12: py312
 
 [testenv]
 basepython =
     py310: python3.10
     py311: python3.11
+    nightlies: python3.11
     py312: python3.12
     # See https://github.com/tox-dev/tox/issues/1548
     {check,docs,cleandocs,viewdocs,build}: python3
+install_command = 
+    {py310,py311,py312,check,docs,cleandocs,viewdocs,build}: python -I -m pip install {opts} {packages}
+    nightlies: python -I -m pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple {opts} {packages}
+pip_pre =
+    {py310,py311,py312,check,docs,cleandocs,viewdocs,build}: false
+    nightlies: true
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = -s


### PR DESCRIPTION
Decided to skip netcdf tests for nightlies and made all non-io specific tests independent of netcdf. This means arviz-base is compatible with numpy 2.0, pandas 3.0 and versions in nightly wheels updated to https://anaconda.org/scientific-python-nightly-wheels/repo.


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview arviz-base end -->