### PR TITLE
auto backend selection

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -229,9 +229,12 @@ which sometimes requires updating default values, for example to use new algorit
 ```{eval-rst}
 .. py:data:: plot.backend
     :type: str
-    :value: "matplotlib"
+    :value: "auto"
 
-    Default plotting backend for :mod:`arviz_plots`, one of "matplotlib", "bokeh" or "none".
+    Default plotting backend for :mod:`arviz_plots`, one of "matplotlib", "plotly", "bokeh", "none"
+    or "auto". If "auto" when setting the value (or when importing the library if using "auto" in a
+    template) the available backends will be checked in the order above, the first one that is found
+    to be available is set as the default plotting backend.
 
 .. py:data:: plot.density_kind
     :type: str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/arviz_base/__init__.py" = ["I", "F401", "E402", "F403"]
+"src/arviz_base/rcparams.py" = ["F401"]
 "src/arviz_base/example_data/**/*" = ["F", "E", "W", "D", "I", "PL"]
 "tests/**/*" = ["D", "PLR2004"]
 "external_tests/**/*" = ["D", "PLR2004"]


### PR DESCRIPTION
add none and plotly as valid options, also allow "auto" so it defaults to an available backend


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--13.org.readthedocs.build/en/13/

<!-- readthedocs-preview arviz-base end -->