### PR TITLE
Use absolute imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   - id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.4.9
+  rev: v0.6.8
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,9 @@ repos:
   rev: v0.4.9
   hooks:
     - id: ruff
-      args: [ --fix, --exit-non-zero-on-fix ]
+      args: [--fix, --exit-non-zero-on-fix]
     - id: ruff-format
       types_or: [ python, pyi ]
-
-- repo: https://github.com/MarcoGorelli/absolufy-imports
-  rev: v0.3.1
-  hooks:
-    - id: absolufy-imports
-      args: ["--never", "--application-directories", "src"]
-      files: ^src/arviz_base/.+\.py$
 
 - repo: https://github.com/MarcoGorelli/madforhooks
   rev: 0.4.1

--- a/external_tests/test_cmdstanpy.py
+++ b/external_tests/test_cmdstanpy.py
@@ -4,12 +4,11 @@ from glob import glob
 
 import numpy as np
 import pytest
+
 from arviz_base import from_cmdstanpy
 from arviz_base.testing import check_multiple_attrs
 
-from .helpers import (  # pylint: disable=unused-import
-    importorskip,
-)
+from .helpers import importorskip  # pylint: disable=unused-import
 
 
 def _create_test_data(target_dir):

--- a/external_tests/test_emcee.py
+++ b/external_tests/test_emcee.py
@@ -3,15 +3,13 @@ import os
 
 import numpy as np
 import pytest
+
 from arviz_base import from_emcee
 from arviz_base.testing import check_multiple_attrs
 
 from .helpers import _emcee_lnprior as emcee_lnprior
 from .helpers import _emcee_lnprob as emcee_lnprob
-from .helpers import (  # pylint: disable=unused-import
-    importorskip,
-    load_cached_models,
-)
+from .helpers import importorskip, load_cached_models  # pylint: disable=unused-import
 
 # Skip all tests if emcee not installed
 emcee = importorskip("emcee")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,9 +73,6 @@ zarr = [
 [tool.ruff]
 line-length = 100
 
-[tool.ruff.lint.flake8-tidy-imports]
-ban-relative-imports = "all"
-
 [tool.ruff.lint]
 select = [
     "F",  # Pyflakes
@@ -86,6 +83,7 @@ select = [
     "UP",  # pyupgrade
     "I",  # isort
     "PL",  # Pylint
+    "TID",  # Absolute imports
 ]
 ignore = [
     "PLR0912",  # too many branches
@@ -101,6 +99,9 @@ ignore = [
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"  # Disallow all relative imports.
 
 [tool.ruff.format]
 docstring-code-format = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,8 +95,8 @@ ignore = [
 "docs/source/**/*.ipynb" = ["D", "E", "F", "I", "NPY", "PL", "TID", "UP", "W"]
 "src/arviz_base/__init__.py" = ["I", "F401", "E402", "F403"]
 "src/arviz_base/example_data/**/*" = ["F", "E", "W", "D", "I", "PL"]
-"tests/**/*" = ["D", "PLR2004"]
-"external_tests/**/*" = ["D", "PLR2004"]
+"tests/**/*" = ["D", "PLR2004", "TID252"]
+"external_tests/**/*" = ["D", "PLR2004", "TID252"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ zarr = [
 [tool.ruff]
 line-length = 100
 
+[tool.ruff.lint.flake8-tidy-imports]
+ban-relative-imports = "all"
+
 [tool.ruff.lint]
 select = [
     "F",  # Pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
+"docs/source/**/*.ipynb" = ["D", "E", "F", "I", "NPY", "PL", "TID", "UP", "W"]
 "src/arviz_base/__init__.py" = ["I", "F401", "E402", "F403"]
 "src/arviz_base/example_data/**/*" = ["F", "E", "W", "D", "I", "PL"]
 "tests/**/*" = ["D", "PLR2004"]

--- a/src/arviz_base/__init__.py
+++ b/src/arviz_base/__init__.py
@@ -5,12 +5,12 @@ import logging
 
 _log = logging.getLogger(__name__)
 
-from .base import generate_dims_coords, dict_to_dataset, make_attrs, ndarray_to_dataarray
-from .converters import *
-from .datasets import load_arviz_data, list_datasets, get_data_home, clear_data_home
-from .io_cmdstanpy import from_cmdstanpy
-from .io_dict import from_dict
-from .io_emcee import from_emcee
-from .rcparams import rcParams, rc_context
-from .sel_utils import *
-from ._version import __version__
+from arviz_base._version import __version__
+from arviz_base.base import dict_to_dataset, generate_dims_coords, make_attrs, ndarray_to_dataarray
+from arviz_base.converters import *
+from arviz_base.datasets import clear_data_home, get_data_home, list_datasets, load_arviz_data
+from arviz_base.io_cmdstanpy import from_cmdstanpy
+from arviz_base.io_dict import from_dict
+from arviz_base.io_emcee import from_emcee
+from arviz_base.rcparams import rc_context, rcParams
+from arviz_base.sel_utils import *

--- a/src/arviz_base/base.py
+++ b/src/arviz_base/base.py
@@ -11,9 +11,9 @@ from typing import TYPE_CHECKING, Any, TypeVar
 import numpy as np
 import xarray as xr
 
-from ._version import __version__
-from .rcparams import rcParams
-from .types import CoordSpec, DictData, DimSpec
+from arviz_base._version import __version__
+from arviz_base.rcparams import rcParams
+from arviz_base.types import CoordSpec, DictData, DimSpec
 
 if TYPE_CHECKING:
     pass

--- a/src/arviz_base/converters.py
+++ b/src/arviz_base/converters.py
@@ -4,9 +4,9 @@ import numpy as np
 import xarray as xr
 from datatree import DataTree, open_datatree
 
-from .base import dict_to_dataset
-from .rcparams import rcParams
-from .utils import _var_names
+from arviz_base.base import dict_to_dataset
+from arviz_base.rcparams import rcParams
+from arviz_base.utils import _var_names
 
 __all__ = ["convert_to_datatree", "convert_to_dataset", "extract"]
 

--- a/src/arviz_base/datasets.py
+++ b/src/arviz_base/datasets.py
@@ -10,7 +10,7 @@ from urllib.request import urlretrieve
 
 from datatree import open_datatree
 
-from .rcparams import rcParams
+from arviz_base.rcparams import rcParams
 
 __all__ = ["get_data_home", "clear_data_home", "list_datasets", "load_arviz_data"]
 

--- a/src/arviz_base/io_cmdstanpy.py
+++ b/src/arviz_base/io_cmdstanpy.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import numpy as np
 from datatree import DataTree
 
-from .base import dict_to_dataset, infer_stan_dtypes, requires
-from .rcparams import rcParams
+from arviz_base.base import dict_to_dataset, infer_stan_dtypes, requires
+from arviz_base.rcparams import rcParams
 
 _log = logging.getLogger(__name__)
 

--- a/src/arviz_base/io_dict.py
+++ b/src/arviz_base/io_dict.py
@@ -4,8 +4,8 @@ import warnings
 
 from datatree import DataTree
 
-from .base import dict_to_dataset
-from .rcparams import rcParams
+from arviz_base.base import dict_to_dataset
+from arviz_base.rcparams import rcParams
 
 
 def from_dict(

--- a/src/arviz_base/io_emcee.py
+++ b/src/arviz_base/io_emcee.py
@@ -5,8 +5,8 @@ import warnings
 import numpy as np
 from datatree import DataTree
 
-from .base import dict_to_dataset
-from .rcparams import rc_context
+from arviz_base.base import dict_to_dataset
+from arviz_base.rcparams import rc_context
 
 
 def _verify_names(sampler, var_names, arg_names, slices):

--- a/src/arviz_base/sel_utils.py
+++ b/src/arviz_base/sel_utils.py
@@ -5,8 +5,8 @@ from itertools import product, tee
 import numpy as np
 import xarray as xr
 
-from .labels import BaseLabeller
-from .rcparams import rcParams
+from arviz_base.labels import BaseLabeller
+from arviz_base.rcparams import rcParams
 
 __all__ = ["xarray_sel_iter", "xarray_var_iter", "xarray_to_ndarray"]
 
@@ -165,9 +165,11 @@ def xarray_sel_iter(
             new_dims = _dims(data, var_name, skip_dims)
             new_dimsidx = [dim_to_idx.get(dim) if dim in dim_to_idx else dim for dim in new_dims]
             vals = [
-                data[var_name].xindexes[dim_to_idx.get(dim)].to_pandas_index().unique().values
-                if dim in dim_to_idx
-                else data[var_name][dim].values
+                (
+                    data[var_name].xindexes[dim_to_idx.get(dim)].to_pandas_index().unique().values
+                    if dim in dim_to_idx
+                    else data[var_name][dim].values
+                )
                 for dim in new_dims
             ]
             dims = _zip_dims(new_dimsidx, vals)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pytest
+
 from arviz_base import from_dict
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -6,6 +6,9 @@ from urllib.parse import urlunsplit
 
 import numpy as np
 import pytest
+from datatree import DataTree
+from xarray.testing import assert_allclose
+
 from arviz_base import (
     dict_to_dataset,
     generate_dims_coords,
@@ -15,8 +18,6 @@ from arviz_base import (
     ndarray_to_dataarray,
 )
 from arviz_base.datasets import LOCAL_DATASETS, REMOTE_DATASETS, RemoteFileMetadata, clear_data_home
-from datatree import DataTree
-from xarray.testing import assert_allclose
 
 netcdf_nightlies_skip = pytest.mark.skipif(
     os.environ.get("NIGHTLIES", False) == "TRUE",

--- a/tests/test_converters.py
+++ b/tests/test_converters.py
@@ -4,6 +4,7 @@ import os
 import numpy as np
 import pytest
 import xarray as xr
+
 from arviz_base import convert_to_dataset, convert_to_datatree, extract
 
 netcdf_nightlies_skip = pytest.mark.skipif(

--- a/tests/test_io_dict.py
+++ b/tests/test_io_dict.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 import numpy as np
 import pytest
+
 from arviz_base import from_dict
 from arviz_base.testing import check_multiple_attrs
 

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -2,6 +2,7 @@
 """Tests for labeller classes."""
 
 import pytest
+
 from arviz_base.labels import (
     BaseLabeller,
     DimCoordLabeller,

--- a/tests/test_rcparams.py
+++ b/tests/test_rcparams.py
@@ -3,6 +3,8 @@ import os
 
 import numpy as np
 import pytest
+from xarray.testing import assert_allclose
+
 from arviz_base import ndarray_to_dataarray
 from arviz_base.rcparams import (
     _make_validate_choice,
@@ -16,7 +18,6 @@ from arviz_base.rcparams import (
     rcParams,
     read_rcfile,
 )
-from xarray.testing import assert_allclose
 
 
 ### Test rcparams classes ###
@@ -119,7 +120,7 @@ def test_make_validate_choice(args, allow_none, typeof):
     validate_choice = _make_validate_choice(accepted_values, allow_none=allow_none, typeof=typeof)
     raise_error, value = args
     if value is None and not allow_none:
-        raise_error = "not one of" if typeof == str else "Could not convert"
+        raise_error = "not one of" if typeof is str else "Could not convert"
     if raise_error:
         with pytest.raises(ValueError, match=raise_error):
             validate_choice(value)
@@ -211,7 +212,13 @@ def test_make_iterable_validator_illegal(args):
 
 @pytest.mark.parametrize(
     "args",
-    [("Only positive", -1), ("Could not convert", "1.3"), (False, "2"), (False, None), (False, 1)],
+    [
+        ("Only positive", -1),
+        ("Could not convert", "1.3"),
+        (False, "2"),
+        (False, None),
+        (False, 1),
+    ],
 )
 def test_validate_positive_int_or_none(args):
     raise_error, value = args

--- a/tests/test_sel_utils.py
+++ b/tests/test_sel_utils.py
@@ -2,6 +2,7 @@
 import numpy as np
 import pytest
 import xarray as xr
+
 from arviz_base import dict_to_dataset, xarray_sel_iter, xarray_to_ndarray
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 # pylint: disable=redefined-outer-name
 import numpy as np
 import pytest
+
 from arviz_base import dict_to_dataset
 from arviz_base.utils import _subset_list, _var_names
 


### PR DESCRIPTION
- Removes the deprecated `absolutify-imports` package from `.pre-commit` and adds a rule in `pyproject.toml` for `ruff` to handle relative import errors.
- Refactors all code that used relative imports.

Resolves #19 

<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--20.org.readthedocs.build/en/20/

<!-- readthedocs-preview arviz-base end -->