### PR TITLE
pin xarray-datatree

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version", "description"]
 dependencies = [
   "numpy>=1.23",
   "xarray>=2022.6.0,<2024.9.1",
-  "xarray-datatree",
+  "xarray-datatree<0.0.15",
   "typing-extensions>=3.10",
 ]
 


### PR DESCRIPTION
xarray-datatree has been archived and the last version published warns about this on import.
I want to make a last release before using the DataTree class from xarray.
