### PR TITLE
Correct a class label ref in  WorkingWithDataTree.ipynb

### DIFF
--- a/docs/source/tutorial/WorkingWithDataTree.ipynb
+++ b/docs/source/tutorial/WorkingWithDataTree.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "# DataTree for Exploratory Analysis of Bayesian Models\n",
     "\n",
-    "Here we present a collection of common manipulations you can use while working with :class:`datatree.DataTree`."
+    "Here we present a collection of common manipulations you can use while working with {class}`datatree.DataTree`."
    ]
   },
   {


### PR DESCRIPTION
Correct a class label ref in  WorkingWithDataTree.ipynb.

The notation is `{class}`, not `:class:`.