### PR TITLE
Correct a typo for "data reorganization"

### DIFF
--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -1,6 +1,6 @@
 # API reference
 
-## Data reoganization
+## Data reorganization
 
 ```{eval-rst}
 .. autosummary::


### PR DESCRIPTION
Correct a typo for "data reorganization".

<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--48.org.readthedocs.build/en/48/

<!-- readthedocs-preview arviz-base end -->