### PR TITLE
Fix link for ArviZ in Context

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -66,7 +66,7 @@ Thus, to install all user facing optional dependencies you should use `arviz-bas
 
 how_to/ConversionGuideEmcee
 tutorial/WorkingWithDataTree
-ArviZ in Context <https://arviz-devs.github.io/Exploratory-Analysis-of-Bayesian-Models/>
+ArviZ in Context <https://arviz-devs.github.io/EABM/>
 :::
 
 :::{toctree}


### PR DESCRIPTION
Update the URL for ArviZ in Context:
https://arviz-devs.github.io/EABM/

The correct link is obtained from the arviz-stats repo.
https://github.com/arviz-devs/arviz-stats/pull/105/files

The old link does not work:
https://arviz-devs.github.io/Exploratory-Analysis-of-Bayesian-Models/


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--49.org.readthedocs.build/en/49/

<!-- readthedocs-preview arviz-base end -->