### PR TITLE
explicitly load example datasets

### DIFF
--- a/src/arviz_base/datasets.py
+++ b/src/arviz_base/datasets.py
@@ -116,7 +116,7 @@ def load_arviz_data(dataset=None, data_home=None, **kwargs):
     """
     if dataset in LOCAL_DATASETS:
         resource = LOCAL_DATASETS[dataset]
-        return open_datatree(resource.filename, **kwargs)
+        return open_datatree(resource.filename, **kwargs).load()
 
     if dataset in REMOTE_DATASETS:
         remote = REMOTE_DATASETS[dataset]
@@ -137,7 +137,7 @@ def load_arviz_data(dataset=None, data_home=None, **kwargs):
                 "({remote.checksum}), file may be corrupted. "
                 "Run `arviz.clear_data_home()` and try again, or please open an issue."
             )
-        return open_datatree(file_path, **kwargs)
+        return open_datatree(file_path, **kwargs).load()
     if dataset is None:
         return dict(itertools.chain(LOCAL_DATASETS.items(), REMOTE_DATASETS.items()))
     raise ValueError(


### PR DESCRIPTION
We are (again as it already happened in current arviz version) having issues with
the somewhat lazy loading of netcdf files by xarray when not using dask.

As we don't have dedicated reading functions and i/o is delegated to xarray,
I am adding a `.load()` to `load_arviz_data` which is what we use to load netcdf files
in the docs. As the example datasets are small enough this should be no problem and in general
be better than not doing it I think.


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--51.org.readthedocs.build/en/51/

<!-- readthedocs-preview arviz-base end -->