### PR TITLE
improve publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,29 +2,49 @@ name: Publish library
 
 on:
   push:
+    branches:
+      - main
     tags:
       # Don't try to be smart about PEP 440 compliance,
       # see https://www.python.org/dev/peps/pep-0440/#appendix-b-parsing-version-strings-with-regular-expressions
       - v*
 
 jobs:
-  publish:
-    environment:
-      name: publish
-      url: https://pypi.org/p/arviz-base
+  build-package:
     runs-on: ubuntu-latest
     permissions:
+      # write attestations and id-token are necessary for attest-build-provenance-github
+      attestations: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
-      - name: Install build dependencies
-        run: python -m pip install build
-      - name: Build package
-        run: python -m build
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@v2
+        with:
+          # Prove that the packages were built in the context of this workflow.
+          attest-build-provenance-github: true
+  publish:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    # Use the `release` GitHub environment to protect the Trusted Publishing (OIDC)
+    # workflow by requiring signoff from a maintainer.
+    environment:
+      name: publish
+      url: https://pypi.org/p/arviz-base
+    needs: build-package
+    permissions:
+      # write id-token is necessary for trusted publishing (OIDC)
+      id-token: write
+    steps:
+      - name: Download Distribution Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # The build-and-inspect-python-package action invokes upload-artifact.
+          # These are the correct arguments from that action.
+          name: Packages
+          path: dist
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        # Implicitly attests that the packages were uploaded in the context of this workflow.


### PR DESCRIPTION
Follow template from https://github.com/pymc-devs/pymc-sphinx-theme/pull/6
which separates building of the package with uploading as recomended by the PyPA.
We were already using trusted publishers so that part doesn't change.


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--52.org.readthedocs.build/en/52/

<!-- readthedocs-preview arviz-base end -->