### PR TITLE
Add support for nd arrays in references_to_dataset

### DIFF
--- a/src/arviz_base/reorg.py
+++ b/src/arviz_base/reorg.py
@@ -414,7 +414,7 @@ def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):
     sample_dims : iterable of hashable, optional
         Sample dimensions in `ds`. The dimensions in the output will be the dimensions
         in `ds` minus `sample_dims` plus optionally a "ref_line_dim" for non-scalar references.
-    ref_dim : list optional
+    ref_dim : str, list optional
         Name for the new dimensions created during reference value broadcasting.
 
     Returns
@@ -469,6 +469,10 @@ def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):
         sample_dims = [sample_dims]
+    if ref_dim is None:
+        ref_dim = ["ref_dim"]
+    if isinstance(ref_dim, str):
+        ref_dim = [ref_dim]
 
     # start covering cases, for dataarray, if its name is a variable convert to dataset
     # if it has no name treat is an array-like
@@ -498,7 +502,7 @@ def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):
                 continue
             ref_values = np.atleast_1d(references[var_name])
             new_dims = ref_values.shape
-            if ref_dim is None:
+            if ref_dim == ["ref_dim"]:
                 new_dim_names = (
                     ["ref_dim"]
                     if len(new_dims) == 1

--- a/src/arviz_base/reorg.py
+++ b/src/arviz_base/reorg.py
@@ -414,15 +414,17 @@ def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):
     sample_dims : iterable of hashable, optional
         Sample dimensions in `ds`. The dimensions in the output will be the dimensions
         in `ds` minus `sample_dims` plus optionally a "ref_line_dim" for non-scalar references.
-    ref_dim : str, list optional
-        Name for the new dimensions created during reference value broadcasting.
+    ref_dim : str or list optional
+        Names for the new dimensions created during reference value broadcasting. Defaults to None.
+        By default, "ref_dim" is added for 1D references and "ref_dim_x" for N-dimensional
+        references when broadcasting over one or more variables.
 
     Returns
     -------
     Dataset
-       A dataset containing a subset of the variables, dimensions, and coordinate names from ds,
-       with an additional dimension "ref_dim" added when multiple references are requested for
-       one or more variables. If references is an N-D array, "ref_dim_x" will be added instead.
+       A Dataset containing a subset of the variables, dimensions, and coordinate names from ds,
+       with additional "ref_dim" dimensions added when multiple references are requested for one
+       or more variables.
 
     See Also
     --------
@@ -469,8 +471,6 @@ def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):
         sample_dims = rcParams["data.sample_dims"]
     if isinstance(sample_dims, str):
         sample_dims = [sample_dims]
-    if ref_dim is None:
-        ref_dim = ["ref_dim"]
     if isinstance(ref_dim, str):
         ref_dim = [ref_dim]
 
@@ -502,14 +502,14 @@ def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):
                 continue
             ref_values = np.atleast_1d(references[var_name])
             new_dims = ref_values.shape
-            if ref_dim == ["ref_dim"]:
+            if ref_dim is None:
                 new_dim_names = (
                     ["ref_dim"]
                     if len(new_dims) == 1
                     else [f"ref_dim_{i}" for i in range(len(new_dims))]
                 )
             else:
-                if len(ref_dim) < len(new_dims):
+                if len(ref_dim) != len(new_dims):
                     raise ValueError(
                         f"ref_dim length ({len(ref_dim)}) does not match reference values "
                         f"length ({len(new_dims)}) for data variable {var_name}"

--- a/tests/test_reorg.py
+++ b/tests/test_reorg.py
@@ -138,7 +138,7 @@ class TestRefToDs:
         assert all(var_name in ref_ds.data_vars for var_name in ("mu", "theta", "tau"))
         assert "chain" not in ref_ds.dims
         assert "draw" not in ref_ds.dims
-        assert "ref_line_dim" not in ref_ds.dims
+        assert "ref_dim_0" not in ref_ds.dims
         assert "school" in ref_ds.dims
 
     def test_array(self, centered_eight):
@@ -149,8 +149,23 @@ class TestRefToDs:
         assert "chain" not in ref_ds.dims
         assert "draw" not in ref_ds.dims
         assert "school" in ref_ds.dims
-        assert "ref_line_dim" in ref_ds.dims
-        assert ref_ds.sizes["ref_line_dim"] == 3
+        assert "ref_dim_0" in ref_ds.dims
+        assert ref_ds.sizes["ref_dim_0"] == 3
+
+    def test_2darray(self, centered_eight):
+        post_ds = centered_eight.posterior.dataset
+        ref_ds = references_to_dataset(
+            np.array([[-1, 0, 1], [0, 1, 2]]), post_ds, sample_dims=["chain", "draw"]
+        )
+        assert isinstance(ref_ds, xr.Dataset)
+        assert all(var_name in ref_ds.data_vars for var_name in ("mu", "theta", "tau"))
+        assert "chain" not in ref_ds.dims
+        assert "draw" not in ref_ds.dims
+        assert "school" in ref_ds.dims
+        assert "ref_dim_0" in ref_ds.dims
+        assert ref_ds.sizes["ref_dim_0"] == 2
+        assert "ref_dim_1" in ref_ds.dims
+        assert ref_ds.sizes["ref_dim_1"] == 3
 
     def test_dict(self, centered_eight):
         post_ds = centered_eight.posterior.dataset
@@ -163,8 +178,8 @@ class TestRefToDs:
         assert "chain" not in ref_ds.dims
         assert "draw" not in ref_ds.dims
         assert "school" in ref_ds.dims
-        assert "ref_line_dim" in ref_ds.dims
-        assert ref_ds.sizes["ref_line_dim"] == 3
+        assert "ref_dim_0" in ref_ds.dims
+        assert ref_ds.sizes["ref_dim_0"] == 3
         assert not np.any(np.isnan(ref_ds["mu"]))
-        assert np.allclose(ref_ds["theta"].isel(ref_line_dim=0), 0)
-        assert np.all(np.isnan(ref_ds["theta"].isel(ref_line_dim=[1, 2])))
+        assert np.allclose(ref_ds["theta"].isel(ref_dim_0=0), 0)
+        assert np.all(np.isnan(ref_ds["theta"].isel(ref_dim_0=[1, 2])))

--- a/tests/test_reorg.py
+++ b/tests/test_reorg.py
@@ -138,7 +138,7 @@ class TestRefToDs:
         assert all(var_name in ref_ds.data_vars for var_name in ("mu", "theta", "tau"))
         assert "chain" not in ref_ds.dims
         assert "draw" not in ref_ds.dims
-        assert "ref_dim_0" not in ref_ds.dims
+        assert "ref_dim" not in ref_ds.dims
         assert "school" in ref_ds.dims
 
     def test_array(self, centered_eight):
@@ -149,8 +149,8 @@ class TestRefToDs:
         assert "chain" not in ref_ds.dims
         assert "draw" not in ref_ds.dims
         assert "school" in ref_ds.dims
-        assert "ref_dim_0" in ref_ds.dims
-        assert ref_ds.sizes["ref_dim_0"] == 3
+        assert "ref_dim" in ref_ds.dims
+        assert ref_ds.sizes["ref_dim"] == 3
 
     def test_2darray(self, centered_eight):
         post_ds = centered_eight.posterior.dataset
@@ -178,8 +178,8 @@ class TestRefToDs:
         assert "chain" not in ref_ds.dims
         assert "draw" not in ref_ds.dims
         assert "school" in ref_ds.dims
-        assert "ref_dim_0" in ref_ds.dims
-        assert ref_ds.sizes["ref_dim_0"] == 3
+        assert "ref_dim" in ref_ds.dims
+        assert ref_ds.sizes["ref_dim"] == 3
         assert not np.any(np.isnan(ref_ds["mu"]))
-        assert np.allclose(ref_ds["theta"].isel(ref_dim_0=0), 0)
-        assert np.all(np.isnan(ref_ds["theta"].isel(ref_dim_0=[1, 2])))
+        assert np.allclose(ref_ds["theta"].isel(ref_dim=0), 0)
+        assert np.all(np.isnan(ref_ds["theta"].isel(ref_dim=[1, 2])))


### PR DESCRIPTION
- Add support for N-D arrays in references_to_dataset.

We should use a more appropriate name, such as `ref_dim`, since it can be applied not only to lines but also to other elements—for example, bands, which may require a 2D array to represent multiple bands (e.g., shaded regions like [(start, end), ...] which will be what users type in for add_reference_bands).