### PR TITLE
Improve docstring for convert_to_dataset

### DIFF
--- a/src/arviz_base/converters.py
+++ b/src/arviz_base/converters.py
@@ -147,40 +147,37 @@ def convert_to_datatree(obj, **kwargs):
 
 
 def convert_to_dataset(obj, *, group="posterior", **kwargs):
-    """Convert a supported object to an xarray dataset.
+    """Convert a supported object to an xarray.Dataset.
 
-    This function is idempotent, in that it will return xarray.Dataset functions
-    unchanged. Raises `ValueError` if the desired group can not be extracted.
-
-    Note this goes through a DataTree object via :func:`convert_to_datatree`.
-    See its docstring for more details.
+    This function is idempotent: if you pass in an xarray.Dataset, it returns it unchanged.
+    If passed another supported object (e.g., dict, DataTree, numpy array), it will be
+    converted to a Dataset via `convert_to_datatree`, and the specified group will be extracted.
 
     Parameters
     ----------
-    obj
-        A supported object to convert to InferenceData.
+    obj : Any
+        A supported object to convert to InferenceData. See `convert_to_datatree` for full list.
     group : str, default "posterior"
-        If `obj` is a dict or numpy array, assigns the resulting xarray
-        dataset to this group.
+        The group name to extract from the converted DataTree.
     **kwargs : dict, optional
-        Keyword arguments passed to :func:`convert_to_datatree`
+        Additional arguments passed to `convert_to_datatree`.
 
     Returns
     -------
     xarray.Dataset
-        New mutable dataset. See :meth:`datatree.DataTree.to_dataset` for more details.
+        The extracted dataset from the converted object.
 
     Raises
     ------
     ValueError
-        If `obj` can't be converted to a DataTree from which to extract the
-        `group` Dataset.
+        If the group cannot be extracted from the resulting DataTree.
 
-    See Also
+    Examples
     --------
-    dict_to_dataset
-        Convert a dictionary of arrays to a :class:`xarray.Dataset` following ArviZ conventions.
+    >>> convert_to_dataset({"mu": np.random.randn(500)})
+    <xarray.Dataset> ...  # Posterior group with 'mu' variable
     """
+
     if isinstance(obj, DataTree) and obj.name == group:
         return obj.to_dataset()
     inference_data = convert_to_datatree(obj, group=group, **kwargs)

--- a/src/arviz_base/converters.py
+++ b/src/arviz_base/converters.py
@@ -177,7 +177,6 @@ def convert_to_dataset(obj, *, group="posterior", **kwargs):
     >>> convert_to_dataset({"mu": np.random.randn(500)})
     <xarray.Dataset> ...  # Posterior group with 'mu' variable
     """
-
     if isinstance(obj, DataTree) and obj.name == group:
         return obj.to_dataset()
     inference_data = convert_to_datatree(obj, group=group, **kwargs)

--- a/src/arviz_base/converters.pyi
+++ b/src/arviz_base/converters.pyi
@@ -1,5 +1,7 @@
 # File generated with docstub
 
+from typing import Any
+
 import numpy as np
 import xarray
 import xarray as xr
@@ -15,5 +17,5 @@ __all__ = [
 
 def convert_to_datatree(obj: Incomplete, **kwargs: Incomplete) -> xarray.DataTree: ...
 def convert_to_dataset(
-    obj: Incomplete, *, group: str = ..., **kwargs: dict
+    obj: Any, *, group: str = ..., **kwargs: dict
 ) -> xarray.Dataset: ...

--- a/src/arviz_base/io_emcee.pyi
+++ b/src/arviz_base/io_emcee.pyi
@@ -41,7 +41,7 @@ class EmceeConverter:
 def from_emcee(
     sampler: emcee.EnsembleSampler | None = ...,
     var_names: list[str] | None = ...,
-    slices: list[ArrayLike | slice] | None = ...,
+    slices: list[ArrayLike] | slice | None = ...,
     arg_names: list[str] | None = ...,
     arg_groups: list[str] | None = ...,
     blob_names: list[str] | None = ...,

--- a/src/arviz_base/io_emcee.pyi
+++ b/src/arviz_base/io_emcee.pyi
@@ -41,7 +41,7 @@ class EmceeConverter:
 def from_emcee(
     sampler: emcee.EnsembleSampler | None = ...,
     var_names: list[str] | None = ...,
-    slices: list[ArrayLike] | slice | None = ...,
+    slices: list[ArrayLike | slice] | None = ...,
     arg_names: list[str] | None = ...,
     arg_groups: list[str] | None = ...,
     blob_names: list[str] | None = ...,


### PR DESCRIPTION
Clarified the docstring for the `convert_to_dataset` function.
- Fixed a typo
- Added a usage example
- Improved parameter documentation


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--56.org.readthedocs.build/en/56/

<!-- readthedocs-preview arviz-base end -->