### PR TITLE
Correct a method label ref in Conversion Guide Emcee

### DIFF
--- a/docs/source/how_to/ConversionGuideEmcee.ipynb
+++ b/docs/source/how_to/ConversionGuideEmcee.ipynb
@@ -1845,7 +1845,7 @@
    "id": "fd01d5ae",
    "metadata": {},
    "source": [
-    "It can also be useful to perform a burn in cut to the MCMC samples (see :meth:`arviz.InferenceData.sel` for more details)"
+    "It can also be useful to perform a burn in cut to the MCMC samples (see {meth}`arviz.InferenceData.sel` for more details)"
    ]
   },
   {


### PR DESCRIPTION
Correct a method label ref in Conversion Guide Emcee.

The notation is `{meth}`, not `:meth:`.