### PR TITLE
Remove direct dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ ci = [
 check = [
     "build",
     "pre-commit",
-    "docstub @ git+https://github.com/scientific-python/docstub@8c35c82585cd50472161abf3a8e191da1c509abf",
+    "docstub",
     "isort",
     "black",
 ]


### PR DESCRIPTION
This is a temporary change; we can revert after release.


<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--73.org.readthedocs.build/en/73/

<!-- readthedocs-preview arviz-base end -->