### PR TITLE
adds label_type parameter in dataset_to_dataarray function

### DIFF
--- a/src/arviz_base/reorg.py
+++ b/src/arviz_base/reorg.py
@@ -206,8 +206,8 @@ def dataset_to_dataarray(
         in the returned `DataArray`. All other variables will be stacked
         into `new_dim`.
     labeller : labeller, optional
-        Labeller instance with a `make_label_flat` method that will be use to
-        generate the coordinate values along `new_dim`.
+        Labeller instance with a `make_label_flat` or `make_label_vert` method that
+        will be use to generate the coordinate values along `new_dim`.
     add_coords : bool, default True
         Return multiple coordinate variables along `new_dim`. These will contain the newly
         generated labels, the stacked variable names, and stacked coordinate values.
@@ -215,6 +215,8 @@ def dataset_to_dataarray(
         Name of the new dimension that is created from stacking variables
         and dimensions not in `sample_dims`.
     label_type : {"flat", "vert"}, default "flat"
+        if "flat", then `labeller.make_label_flat` method is used to generate the labels and if
+        "vert", then `labeller.make_label_vert` method is used.
 
     Returns
     -------

--- a/src/arviz_base/reorg.pyi
+++ b/src/arviz_base/reorg.pyi
@@ -49,6 +49,7 @@ def dataset_to_dataarray(
     labeller: Labeller | None = ...,
     add_coords: bool = ...,
     new_dim: Hashable = ...,
+    label_type: Literal["flat", "vert"] = ...,
 ) -> xarray.DataArray: ...
 def dataset_to_dataframe(
     ds: xarray.Dataset,

--- a/tests/test_reorg.py
+++ b/tests/test_reorg.py
@@ -133,6 +133,22 @@ class TestDsToDa:
         assert "theta[school: Choate]" in post_da.coords["label"].to_numpy()
         assert "theta" in post_da.coords["variable"].to_numpy()
 
+    @pytest.mark.parametrize("label_type", ["flat", "vert"])
+    def test_label_type(self, label_type, centered_eight):
+        post_ds = centered_eight.posterior.dataset
+        post_da = dataset_to_dataarray(post_ds, labeller=DimCoordLabeller(), label_type=label_type)
+        assert isinstance(post_da, xr.DataArray)
+        assert "label" in post_da.dims
+        assert post_da.sizes["label"] == 10
+        assert "mu" in post_da.coords["label"].to_numpy()
+        if label_type == "vert":
+            assert "theta\nschool: Choate" in post_da.coords["label"].to_numpy()
+            assert "theta\nschool: Deerfield" in post_da.coords["label"].to_numpy()
+        elif label_type == "flat":
+            assert "theta[school: Choate]" in post_da.coords["label"].to_numpy()
+            assert "theta[school: Deerfield]" in post_da.coords["label"].to_numpy()
+        assert "theta" in post_da.coords["variable"].to_numpy()
+
     def test_no_coords(self, centered_eight):
         post_ds = centered_eight.posterior.dataset
         post_da = dataset_to_dataarray(post_ds, add_coords=False)


### PR DESCRIPTION
As discussed in https://github.com/arviz-devs/arviz-plots/pull/300 , sometimes we don't want labels to be generated using `make_label_flat`, instead we want `make_label_vert`. So this PR adds a new parameter which will specify the label type we want.

<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--81.org.readthedocs.build/en/81/

<!-- readthedocs-preview arviz-base end -->