### PR TITLE
Patch CI so it passes again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ funding = "https://opencollective.com/arviz"
 
 [project.optional-dependencies]
 test = [
+    "xarray!=2025.8.0",
     "pytest",
     "pytest-cov",
     "scipy",


### PR DESCRIPTION
CI is failing due to an issue upstream with xarray. I opened an issue and there is already an
open PR to fix it. I think it has high probability of making it into the next release
so I am adding a `!2025.8.0` constraint into the testing dependencies to avoid using
the offending xarray version. Next version should hopefully include the fix and
we won't need to worry about removing the pin later on
