### PR TITLE
Add new citations from `loo_score()`

### DIFF
--- a/src/arviz_base/references.bib
+++ b/src/arviz_base/references.bib
@@ -21,6 +21,17 @@
       url={https://arxiv.org/abs/1604.00695},
 }
 
+@article{Bolin_2023,
+	title = {Local scale invariance and robustness of proper scoring rules},
+	author = {Bolin, David and Wallin, Jonas},
+	journal = {Statistical Science},
+	volume = {38},
+	number = {1},
+	pages = {140--159},
+	year = {2023},
+	doi = {10.1214/22-STS864},
+	url = {https://doi.org/10.1214/22-STS864},
+}
 @article{Botev_2010,
 	author = {Z. I. Botev and J. F. Grotowski and D. P. Kroese},
 	title = {{Kernel density estimation via diffusion}},
@@ -59,6 +70,18 @@
 	number = {3},
 	pages = {307-309},
 	year  = {2019}
+}
+
+@article{Gneiting_2007,
+	title = {Strictly Proper Scoring Rules, Prediction, and Estimation},
+	author = {Gneiting, Tilmann and Raftery, Adrian E.},
+	journal = {Journal of the American Statistical Association},
+	volume = {102},
+	number = {477},
+	pages = {359--378},
+	year = {2007},
+	doi = {10.1198/016214506000001437},
+	url = {https://doi.org/10.1198/016214506000001437},
 }
 
 @article{Heck_2019,
@@ -190,6 +213,18 @@
   year={2025},
 }
 
+@article{Taillardat_2016,
+	title = {Calibrated ensemble forecasts using quantile regression forests and ensemble model output statistics},
+	author = {Taillardat, Maxime and Mestre, Olivier and Zamo, Micha{\"e}l and Naveau, Philippe},
+	journal = {Monthly Weather Review},
+	volume = {144},
+	number = {6},
+	pages = {2375--2393},
+	year = {2016},
+	doi = {10.1175/MWR-D-15-0260.1},
+	url = {https://doi.org/10.1175/MWR-D-15-0260.1},
+}
+
 @article{Taylor_2008,
 	title = {Automatic bandwidth selection for circular density estimation},
 	volume = {52},
@@ -290,7 +325,6 @@
 	doi= {https://doi.org/10.48550/arXiv.math/0505419},
 	url={https://arxiv.org/abs/math/0505419},
 }
-
 
 @misc{sivula_2025,
 	title={Uncertainty in Bayesian Leave-One-Out Cross-Validation Based Model Comparison},


### PR DESCRIPTION
This adds new references used in the `loo_score()` function seen here [#196](https://github.com/arviz-devs/arviz-stats/pull/196)

<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview arviz-base end -->