### PR TITLE
Correct two more typos in documentation

### DIFF
--- a/src/arviz_base/io_cmdstanpy.py
+++ b/src/arviz_base/io_cmdstanpy.py
@@ -453,7 +453,7 @@ def from_cmdstanpy(
     dtypes : dict, str or cmdstanpy.CmdStanModel, optional
         A dictionary containing dtype information (int, float) for parameters.
         If input is a string, it is assumed to be a model code or path to model code file.
-        Model code can extracted from cmdstanpy.CmdStanModel object.
+        Model code can be extracted from cmdstanpy.CmdStanModel object.
 
     Returns
     -------

--- a/src/arviz_base/reorg.py
+++ b/src/arviz_base/reorg.py
@@ -283,7 +283,7 @@ def dataset_to_dataframe(ds, sample_dims=None, labeller=None, multiindex=False, 
 
     Examples
     --------
-    The output will have whatever is uses as `sample_dims` as the columns of
+    The output will have whatever that uses `sample_dims` as the columns of
     the DataFrame, so when these are much longer we might want to transpose the
     output:
 


### PR DESCRIPTION
Correct two more typos in documentation

<!-- readthedocs-preview arviz-base start -->
----
📚 Documentation preview 📚: https://arviz-base--102.org.readthedocs.build/en/102/

<!-- readthedocs-preview arviz-base end -->