### PR TITLE
Use Zenodo as a backup source for datasets

### DIFF
--- a/src/arviz_base/datasets.py
+++ b/src/arviz_base/datasets.py
@@ -139,8 +139,10 @@ def load_arviz_data(dataset=None, data_home=None, **kwargs):
                     os.remove(file_path)
 
             if not download_success:
-                github_url = f"https://raw.githubusercontent.com/arviz-devs/arviz_example_data/main/data/{remote.filename}"
-                urlretrieve(github_url, file_path)
+                zenodo_url = (
+                    f"https://zenodo.org/records/18241644/files/{remote.filename}?download=1"
+                )
+                urlretrieve(zenodo_url, file_path)
 
         checksum = _sha256(file_path)
         if remote.checksum != checksum:


### PR DESCRIPTION
We have been experiencing several issues with figshare. Including HTTP 403, and more recently, empty files being downloaded. Here I am adding GitHub as a second source for automatic downloading. Not sure if this is a good solution. Not all necessary files are at https://github.com/arviz-devs/arviz_example_data/tree/main/data, so for this to really work, we will need to add a few more files there. 