### PR TITLE
docs: add CmdStanPy getting-started example

### DIFF
--- a/docs/source/how_to/ConversionGuideCmdStanPy.md
+++ b/docs/source/how_to/ConversionGuideCmdStanPy.md
@@ -1,6 +1,7 @@
 # CmdStanPy Conversion Guide
 
-ArviZ can convert CmdStanPy sampling results into the ArviZ data structure using `from_cmdstanpy`.
+ArviZ offers the {func}`~arviz_base.from_cmdstanpy` function to convert CmdStanPy results into
+`DataTree`, the data structure used by ArviZ.
 
 ```python
 import arviz_base as az
@@ -10,4 +11,5 @@ model = CmdStanModel(stan_file="bernoulli.stan")
 fit = model.sample({"N": 10, "y": [0, 1, 0, 0, 0, 0, 0, 0, 0, 1]})
 
 idata = az.from_cmdstanpy(posterior=fit)
-az.plot_trace_dist(idata)
+idata
+```

--- a/docs/source/how_to/ConversionGuideEmcee.ipynb
+++ b/docs/source/how_to/ConversionGuideEmcee.ipynb
@@ -8726,6 +8726,14 @@
     "%load_ext watermark\n",
     "%watermark -n -u -v -iv -w"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98d3d8ac-ee43-49c8-927e-a0021fcd2bf0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR addresses feedback from the JOSS review regarding discoverability
of CmdStanPy support.

Changes:
- Add a minimal CmdStanPy → ArviZ example to the getting started page
- Link to the CmdStanPy conversion guide for further details

This should make it clearer to new users how to use ArviZ with CmdStanPy
without needing to search the API reference.

