### PR TITLE
docs: clarify DataArray behavior in dict_to_dataset

### DIFF
--- a/src/arviz_base/base.py
+++ b/src/arviz_base/base.py
@@ -241,6 +241,10 @@ def dict_to_dataset(
     ----------
     data : mapping of {hashable_key : array_like}
         Data to convert. Keys are variable names.
+
+        If values in `data` are :class:`xarray.DataArray` objects, they are
+        preserved as-is and their dimensions and coordinates are not modified.
+
     attrs : mapping of {hashable_key : any}, optional
         JSON-like arbitrary metadata to attach to the dataset, in addition to default
         attributes added by :func:`make_attrs`.

--- a/src/arviz_base/io_dict.py
+++ b/src/arviz_base/io_dict.py
@@ -36,6 +36,10 @@ def from_dict(
         variables that should be stored in that group. These inner dictionaries
         are passed to :func:`dict_to_dataset`.
 
+        If values in these inner dictionaries are :class:`xarray.DataArray`
+        objects, they are preserved as-is and their dimensions and
+        coordinates are not modified.
+
         Depending on the group name, the arguments used when calling `dict_to_dataset`
         can take different arguments from their defaults:
 


### PR DESCRIPTION
Clarify in dict_to_dataset documentation that when values in `data`
are xarray.DataArray objects, they are preserved as is and
dimensions/coordinates are not modified.

This matches the existing behavior in ndarray_to_dataarray.