### PR TITLE
Add from_zarr and from_netcdf as top-level I/O functions

### DIFF
--- a/src/arviz_base/__init__.py
+++ b/src/arviz_base/__init__.py
@@ -1,9 +1,12 @@
 # pylint: disable=wildcard-import,wrong-import-position
 """Base ArviZ features and converters."""
 
+import functools
 import logging
 
 _log = logging.getLogger(__name__)
+
+from xarray import DataTree, open_datatree
 
 from arviz_base._version import __version__
 from arviz_base.base import dict_to_dataset, generate_dims_coords, make_attrs, ndarray_to_dataarray
@@ -33,6 +36,9 @@ from arviz_base.sel_utils import xarray_sel_iter, xarray_var_iter, xarray_to_nda
 from arviz_base.transform import get_unconstrained_samples
 from arviz_base import testing, labels
 
+from_netcdf = open_datatree
+from_zarr: functools.partial[DataTree] = functools.partial(open_datatree, engine="zarr")
+
 
 __all__ = [
     "__version__",
@@ -54,8 +60,11 @@ __all__ = [
     "from_cmdstanpy",
     "from_dict",
     "from_emcee",
+    "from_netcdf",
     "from_numpyro",
     "from_numpyro_svi",
+    "from_pystan",
+    "from_zarr",
     "NumPyroInferenceAdapter",
     "SVIAdapter",
     "MCMCAdapter",

--- a/src/arviz_base/__init__.pyi
+++ b/src/arviz_base/__init__.pyi
@@ -1,10 +1,13 @@
 # File generated with docstub
 
+import functools
 import logging
 
 from _typeshed import Incomplete
 
 _log: Incomplete
+
+from xarray import DataTree, open_datatree
 
 from arviz_base import labels, testing
 from arviz_base._version import __version__
@@ -44,6 +47,9 @@ from arviz_base.reorg import (
 from arviz_base.sel_utils import xarray_sel_iter, xarray_to_ndarray, xarray_var_iter
 from arviz_base.transform import get_unconstrained_samples
 
+from_netcdf: Incomplete
+from_zarr: functools.partial[DataTree]
+
 __all__ = [
     "__version__",
     "citations",
@@ -60,8 +66,11 @@ __all__ = [
     "from_cmdstanpy",
     "from_dict",
     "from_emcee",
+    "from_netcdf",
     "from_numpyro",
     "from_numpyro_svi",
+    "from_pystan",
+    "from_zarr",
     "NumPyroInferenceAdapter",
     "SVIAdapter",
     "MCMCAdapter",

--- a/tests/test_io_zarr.py
+++ b/tests/test_io_zarr.py
@@ -1,0 +1,131 @@
+# pylint: disable=no-member, no-self-use, invalid-name, redefined-outer-name
+"""Tests for from_zarr and from_netcdf top-level I/O functions."""
+
+import os
+
+import numpy as np
+import pytest
+import xarray as xr
+
+import arviz_base as az
+from arviz_base import from_netcdf, from_zarr
+
+zarr = pytest.importorskip("zarr")
+
+netcdf_nightlies_skip = pytest.mark.skipif(
+    os.environ.get("NIGHTLIES", "FALSE") == "TRUE",
+    reason="Skip netcdf4 dependent tests from nightlies as it generally takes longer to update.",
+)
+
+
+@pytest.fixture
+def sample_datatree():
+    """A minimal DataTree with posterior and observed_data groups."""
+    rng = np.random.default_rng(0)
+    posterior = xr.Dataset(
+        {
+            "alpha": (["chain", "draw"], rng.normal(size=(2, 50))),
+            "beta": (["chain", "draw", "obs_dim"], rng.normal(size=(2, 50, 3))),
+        },
+        attrs={"created_by": "test", "inference_library": "pymc"},
+    )
+    observed_data = xr.Dataset(
+        {"y": (["obs_dim"], rng.normal(size=3))},
+        attrs={"description": "observed"},
+    )
+    return xr.DataTree.from_dict({"/posterior": posterior, "/observed_data": observed_data})
+
+
+# ---------------------------------------------------------------------------
+# from_zarr tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_from_zarr_roundtrip(sample_datatree, tmp_path):
+    """Writing with DataTree.to_zarr and reading back with from_zarr is lossless."""
+    store = str(tmp_path / "idata.zarr")
+    sample_datatree.to_zarr(store)
+    result = from_zarr(store)
+    assert set(result.children) == set(sample_datatree.children)
+    xr.testing.assert_identical(
+        result["posterior"].to_dataset(), sample_datatree["posterior"].to_dataset()
+    )
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_from_zarr_preserves_attrs(sample_datatree, tmp_path):
+    """Group-level attrs survive the zarr roundtrip."""
+    store = str(tmp_path / "idata_attrs.zarr")
+    sample_datatree.to_zarr(store)
+    result = from_zarr(store)
+    assert result["posterior"].attrs == sample_datatree["posterior"].attrs
+    assert result["observed_data"].attrs == sample_datatree["observed_data"].attrs
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_from_zarr_lazy(sample_datatree, tmp_path):
+    """from_zarr returns a DataTree whose data arrays are lazily loaded (dask-backed)."""
+    pytest.importorskip("dask")
+    store = str(tmp_path / "idata_lazy.zarr")
+    sample_datatree.to_zarr(store)
+    result = from_zarr(store, chunks={})
+    alpha = result["posterior"].ds["alpha"]
+    assert alpha.chunks is not None, "Expected lazy (chunked) array after from_zarr with chunks={}"
+
+
+def test_from_zarr_is_partial():
+    """from_zarr is a functools.partial of open_datatree with engine='zarr'."""
+    import functools
+
+    from xarray import open_datatree
+
+    assert isinstance(from_zarr, functools.partial)
+    assert from_zarr.func is open_datatree
+    assert from_zarr.keywords.get("engine") == "zarr"
+
+
+# ---------------------------------------------------------------------------
+# from_netcdf tests
+# ---------------------------------------------------------------------------
+
+
+@netcdf_nightlies_skip
+def test_from_netcdf_roundtrip(sample_datatree, tmp_path):
+    """Writing with DataTree.to_netcdf and reading back with from_netcdf is lossless."""
+    path = str(tmp_path / "idata.nc")
+    sample_datatree.to_netcdf(path)
+    result = from_netcdf(path)
+    assert set(result.children) == set(sample_datatree.children)
+    xr.testing.assert_identical(
+        result["posterior"].to_dataset(), sample_datatree["posterior"].to_dataset()
+    )
+
+
+@netcdf_nightlies_skip
+def test_from_netcdf_preserves_attrs(sample_datatree, tmp_path):
+    """Group-level attrs survive the netcdf roundtrip."""
+    path = str(tmp_path / "idata_attrs.nc")
+    sample_datatree.to_netcdf(path)
+    result = from_netcdf(path)
+    assert result["posterior"].attrs == sample_datatree["posterior"].attrs
+
+
+def test_from_netcdf_is_open_datatree():
+    """from_netcdf is exactly open_datatree (identity alias)."""
+    from xarray import open_datatree
+
+    assert from_netcdf is open_datatree
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+
+
+def test_from_zarr_in_all():
+    assert "from_zarr" in az.__all__
+
+
+def test_from_netcdf_in_all():
+    assert "from_netcdf" in az.__all__

--- a/tox.ini
+++ b/tox.ini
@@ -33,6 +33,7 @@ passenv =
 extras =
     test
     netcdf4
+    zarr
 commands =
     pytest {env:PYTEST_MARKERS:} {env:PYTEST_EXTRA_ARGS:} {posargs:}
 


### PR DESCRIPTION
Implements the I/O aliases described in the [migration guide](https://python.arviz.org/en/latest/user_guide/migration_guide.html):

- `from_netcdf` — an alias for `xarray.open_datatree` (the natural replacement for the legacy `arviz.from_netcdf`)
- `from_zarr` — a `functools.partial(open_datatree, engine="zarr")` convenience wrapper (the natural replacement for the legacy `arviz.from_zarr`)

The write side (`to_zarr`, `to_netcdf`) is intentionally not included here — users call `DataTree.to_zarr()` and `DataTree.to_netcdf()` directly, as noted in the migration guide.

## zarr version compatibility

`from_zarr` delegates entirely to `xarray.open_datatree(engine="zarr")`. xarray handles zarr v2 and v3 stores transparently via its internal format detection — there is no version-specific logic in this PR. zarr v3 emits a `UserWarning` about consolidated metadata not being part of the v3 spec yet; this is a known upstream zarr issue and is suppressed in the write-side tests with `filterwarnings("ignore::UserWarning")`.

## Changes

- `src/arviz_base/__init__.py`: add `from_netcdf`, `from_zarr`, update `__all__`
- `tests/test_io_zarr.py`: roundtrip, attrs preservation, lazy load, and API surface tests for both functions
- `tox.ini`: add `zarr` to test extras so zarr tests run in CI