### PR TITLE
fix post release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,7 +1,7 @@
 name: Post-release
 on:
   release:
-    types: [published, released]
+    types: [published]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
From what I can gather out of this [doc page](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#release)
and the fact that the post release job seems to run twice (and one of them ends up failing due to
branch name issues) we are triggering it twice because `published` and `released` are very similar.

We should use `released` if we don't want the job to run whenever we create a pre-release,
`published` otherwise. cc @aloctavodia
