### PR TITLE
pydata inspired fixes

### DIFF
--- a/src/arviz_base/reorg.py
+++ b/src/arviz_base/reorg.py
@@ -389,6 +389,7 @@ def explode_dataset_dims(ds, dim, labeller=None, dim_to_idx=None):
     labeller : labeller, optional
         Instance of a labeller class used to label the slices generated when exploding along `dim`.
         The method ``make_label_flat`` is used.
+    dim_to_idx : mapping of {str : str}, optional
 
     Returns
     -------
@@ -419,10 +420,16 @@ def explode_dataset_dims(ds, dim, labeller=None, dim_to_idx=None):
     ):
         new_var = labeller.make_label_flat(var_name, sel, isel)
         new_da = ds[var_name].sel(sel, drop=True)
-        if dim_to_idx is not None:
+        present_dim_to_idx = (
+            {} if dim_to_idx is None else {k: v for k, v in dim_to_idx.items() if k in new_da.dims}
+        )
+        if present_dim_to_idx:
             new_da = new_da.rename(
-                {key: f"{key}_{labeller.sel_to_str(sel, isel)}" for key in dim_to_idx.keys()}
-            ).drop_vars(list(dim_to_idx.values()))
+                {
+                    key: f"{key}_{labeller.sel_to_str(sel, isel)}"
+                    for key in present_dim_to_idx.keys()
+                }
+            ).drop_vars(list(present_dim_to_idx.values()))
         out[new_var] = new_da
     return xr.Dataset(out)
 

--- a/src/arviz_base/reorg.py
+++ b/src/arviz_base/reorg.py
@@ -377,7 +377,7 @@ def dataset_to_dataframe(ds, sample_dims=None, labeller=None, multiindex=False, 
     return df
 
 
-def explode_dataset_dims(ds, dim, labeller=None):
+def explode_dataset_dims(ds, dim, labeller=None, dim_to_idx=None):
     """Explode dims of a dataset so each slice along them becomes its own variable.
 
     Parameters
@@ -413,14 +413,18 @@ def explode_dataset_dims(ds, dim, labeller=None):
         dim = [dim]
     if labeller is None:
         labeller = BaseLabeller()
-    return xr.Dataset(
-        {
-            labeller.make_label_flat(var_name, sel, isel): ds[var_name].sel(sel, drop=True)
-            for var_name, sel, isel in xarray_sel_iter(
-                ds, skip_dims={d for d in ds.dims if d not in dim}
-            )
-        }
-    )
+    out = {}
+    for var_name, sel, isel in xarray_sel_iter(
+        ds, skip_dims={d for d in ds.dims if d not in dim}, dim_to_idx=dim_to_idx
+    ):
+        new_var = labeller.make_label_flat(var_name, sel, isel)
+        new_da = ds[var_name].sel(sel, drop=True)
+        if dim_to_idx is not None:
+            new_da = new_da.rename(
+                {key: f"{key}_{labeller.sel_to_str(sel, isel)}" for key in dim_to_idx.keys()}
+            ).drop_vars(list(dim_to_idx.values()))
+        out[new_var] = new_da
+    return xr.Dataset(out)
 
 
 def references_to_dataset(references, ds, sample_dims=None, ref_dim=None):

--- a/src/arviz_base/reorg.pyi
+++ b/src/arviz_base/reorg.pyi
@@ -1,6 +1,6 @@
 # File generated with docstub
 
-from collections.abc import Hashable, Iterable, Sequence
+from collections.abc import Hashable, Iterable, Mapping, Sequence
 from numbers import Number
 from typing import Literal
 
@@ -59,7 +59,10 @@ def dataset_to_dataframe(
     new_dim: Hashable = ...,
 ) -> pandas.DataFrame: ...
 def explode_dataset_dims(
-    ds: Dataset, dim: Hashable | Sequence[Hashable], labeller: Labeller | None = ...
+    ds: Dataset,
+    dim: Hashable | Sequence[Hashable],
+    labeller: Labeller | None = ...,
+    dim_to_idx: Mapping[str, str] | None = ...,
 ) -> Dataset: ...
 def references_to_dataset(
     references: Number | ArrayLike | dict | DataArray | Dataset,

--- a/tests/test_reorg.py
+++ b/tests/test_reorg.py
@@ -4,8 +4,14 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from arviz_base import dataset_to_dataarray, dataset_to_dataframe, extract, references_to_dataset
-from arviz_base.labels import DimCoordLabeller
+from arviz_base import (
+    dataset_to_dataarray,
+    dataset_to_dataframe,
+    explode_dataset_dims,
+    extract,
+    references_to_dataset,
+)
+from arviz_base.labels import BaseLabeller, DimCoordLabeller
 
 
 class TestExtract:
@@ -263,3 +269,44 @@ class TestRefToDs:
         assert not np.any(np.isnan(ref_ds["mu"]))
         assert np.allclose(ref_ds["theta"].isel(ref_dim=0), 0)
         assert np.all(np.isnan(ref_ds["theta"].isel(ref_dim=[1, 2])))
+
+
+class TestExplodeDsDims:
+    def test_basic(self, centered_eight):
+        ds = explode_dataset_dims(
+            centered_eight.posterior.dataset, "school", labeller=BaseLabeller()
+        )
+        assert len(ds.data_vars) == 10
+        assert set(ds.data_vars) == set(
+            ["mu", "tau"]
+            + [f"theta[{school}]" for school in centered_eight.posterior["school"].to_numpy()]
+        )
+
+    def test_labeller(self, centered_eight):
+        ds = explode_dataset_dims(
+            centered_eight.posterior.dataset, "school", labeller=DimCoordLabeller()
+        )
+        assert len(ds.data_vars) == 10
+        assert set(ds.data_vars) == set(
+            ["mu", "tau"]
+            + [
+                f"theta[school: {school}]"
+                for school in centered_eight.posterior["school"].to_numpy()
+            ]
+        )
+
+    def test_dim_to_idx(self, centered_eight):
+        input_ds = (
+            centered_eight.posterior.to_dataset()
+            .assign_coords(region=(["school"], list("aaabbbbb")))
+            .set_xindex("region")
+        )
+        ds = explode_dataset_dims(
+            input_ds, "school", labeller=BaseLabeller(), dim_to_idx={"school": "region"}
+        )
+        assert len(ds.data_vars) == 4
+        assert set(ds.data_vars) == {"mu", "tau", "theta[a]", "theta[b]"}
+        assert "school_a" in ds["theta[a]"].dims
+        assert ds.sizes["school_a"] == 3
+        assert "school_b" in ds["theta[b]"].dims
+        assert ds.sizes["school_b"] == 5


### PR DESCRIPTION
First batch of fixes and improvements related to my pydata tutorial.
This is mostly a temporal workaround I think but I wanted to generate
ppc related plots for specific subsets of data. I did some changes in `plot_ppc_dist`
which was mostly there when given the right facetting strategy,
but most other plots will take non negligible work.

On the other hand, by using this helper function we can convert a multidimensional
variable into multiple independent variables which already plays well with most plots.
