### PR TITLE
Replaces the version-named test envs with tox -e test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,27 +3,24 @@ envlist =
     check
     docs
     nightlies
-    {py312,py313,py314}{,-coverage}
+    {test}{,-coverage}
 # See https://tox.readthedocs.io/en/latest/example/package.html#flit
 isolated_build = True
 isolated_build_env = build
 labels =
-    dev = check, cleandocs, docs, livedocs, viewdocs, py312, py313, py314, nightlies
+    dev = check, cleandocs, docs, livedocs, viewdocs, test, nightlies
 
 [gh-actions]
 python =
-    3.12: py312-coverage
-    3.13: py313-coverage, check, nightlies
-    3.14: py314-coverage
+    3.12: test-coverage
+    3.13: test-coverage, check, nightlies
+    3.14: test-coverage
 
 [testenv]
 description = Run ArviZ-base tests
 basepython =
-    py312: python3.12
-    py313: python3.13
-    py314: python3.14
     # See https://github.com/tox-dev/tox/issues/1548
-    {check,docs,cleandocs,viewdocs,build,nightlies}: python3
+    {check,docs,cleandocs,viewdocs,build,nightlies,test}: python3
 setenv =
     PYTHONUNBUFFERED = yes
     PYTEST_EXTRA_ARGS = -s


### PR DESCRIPTION
- developers run tox -e test instead of tox -e py312
- kept the [gh-actions] and basepython sections (just pointed them at test), so CI keeps running plain tox and check/nightlies still run